### PR TITLE
Fix install script instructions

### DIFF
--- a/bambu_ai_assistant/install_bambu_ai.bat
+++ b/bambu_ai_assistant/install_bambu_ai.bat
@@ -46,13 +46,6 @@ if %ERRORLEVEL% EQU 0 (
 )
 
 echo.
-echo ========================================
-echo Files you need to update manually:
-echo ========================================
-echo 1. REPLACE: chat_gui.py (with enhanced version)
-echo 2. REPLACE: realtime_helper.py (with vision helper) 
-echo 3. KEEP: slicer_control.py (no changes needed)
-echo 4. CREATE: requirements.txt (optional, for future installs)
-echo.
+echo Installation finished. Press any key to exit.
 pause
 


### PR DESCRIPTION
## Summary
- remove outdated section from installer script
- add a concise completion message

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be2480e2c832ea934ec18e1207f60