### PR TITLE
Fix return in recommendation helper

### DIFF
--- a/bambu_ai_assistant/realtime_helper.py
+++ b/bambu_ai_assistant/realtime_helper.py
@@ -296,4 +296,5 @@ def generate_recommendations(report, user_query):
             recommendations.append("Check printer connection and power")
         else:
             recommendations.append("Ready to start print")
-    
+
+    return recommendations


### PR DESCRIPTION
## Summary
- remove stray shell prompt from `realtime_helper.py`
- ensure the generate_recommendations function returns its list properly

## Testing
- `python3 -m py_compile bambu_ai_assistant/realtime_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_685be2334fc0832ebad079115a66f79d